### PR TITLE
Add chart parameter to optionally deploy eventsapi

### DIFF
--- a/chart/templates/eventsapi-deployment.yaml
+++ b/chart/templates/eventsapi-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableEventsApi }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,3 +26,4 @@ spec:
               value: {{ .Values.eventsApiS3Prefix }}
           ports:
             - containerPort: 80
+{{- end }}

--- a/chart/templates/eventsapi-service.yaml
+++ b/chart/templates/eventsapi-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableEventsApi }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,3 +9,4 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+{{- end }}

--- a/chart/templates/moodle-deployment.yaml
+++ b/chart/templates/moodle-deployment.yaml
@@ -39,8 +39,10 @@ spec:
               value: {{ .Values.moodleDataRoot }}
             - name: MOODLE_DOCKER_WWWROOT
               value: {{ .Values.moodleWebRoot }}
+            {{- if .Values.enableEventsApi }}
             - name: EVENTSAPI_SERVER
               value: {{ .Chart.Name }}-eventsapi-{{ .Values.deploymentName }}
+            {{- end }}
             {{- if .Values.enableMailhog }}
             - name: MOODLE_DOCKER_SMTPHOST
               value: {{ .Chart.Name }}-mailhog-{{ .Values.deploymentName }}:1025

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,7 @@ dbStorageGb: 1
 moodleStorageGb: 1
 moodleDataRoot: "/var/www/moodledata"
 moodleWebRoot: "http://localhost:8888"
+enableEventsApi: true
 enableMailhog: true
 
 # These values should be set if you want data to be stored in S3 vs logged


### PR DESCRIPTION
In a [prior PR](https://github.com/openstax/raise-moodle-spikes/pull/4), we added a parameter to make the deployment of a service optional in the Helm chart. This PR adds a similar option for the Events API as it isn't really required unless we're specifically doing a demo / test that needs it. With this change developers can tune a k8s deployment to include the services they need with the only required ones being `moodle` and `postgres`.