### PR TITLE
Update version of raise-moodlecli used by daily analyzer

### DIFF
--- a/reporting/raise-metrics-analyzer/requirements.txt
+++ b/reporting/raise-metrics-analyzer/requirements.txt
@@ -1,3 +1,3 @@
-awscli==1.25.75
-git+https://github.com/openstax/raise-moodlecli@3ea86c7
+awscli==1.25.97
+git+https://github.com/openstax/raise-moodlecli@1bb2f9e
 pytz==2022.2.1


### PR DESCRIPTION
Now that the local_raise plugin exists in production, we can use the latest version of the CLI to push UUID values to S3.